### PR TITLE
Fixed typing mistake

### DIFF
--- a/src/main/java/io/gomint/proxprox/network/DownstreamConnection.java
+++ b/src/main/java/io/gomint/proxprox/network/DownstreamConnection.java
@@ -8,7 +8,6 @@
 package io.gomint.proxprox.network;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import com.sun.org.apache.regexp.internal.RE;
 import io.gomint.jraknet.*;
 import io.gomint.proxprox.ProxProx;
 import io.gomint.proxprox.api.entity.Server;
@@ -79,7 +78,7 @@ public class DownstreamConnection extends AbstractConnection implements Server, 
                     case CONNECTION_ATTEMPT_SUCCEEDED:
                         // We got accepted *yay*
                         DownstreamConnection.this.setup();
-                        DownstreamConnection.this.upstreamConnection.onDownSteamConnected( DownstreamConnection.this );
+                        DownstreamConnection.this.upstreamConnection.onDownStreamConnected( DownstreamConnection.this );
                         break;
 
                     case CONNECTION_CLOSED:

--- a/src/main/java/io/gomint/proxprox/network/UpstreamConnection.java
+++ b/src/main/java/io/gomint/proxprox/network/UpstreamConnection.java
@@ -128,7 +128,7 @@ public class UpstreamConnection extends AbstractConnection implements Player {
     @Override
     protected boolean handlePacket( PacketBuffer buffer, PacketReliability reliability, int orderingChannel, boolean batched ) {
         // Store in debugger
-        this.networkDebugger.addPacket( new PacketBuffer( buffer.getBuffer(),0 ), batched );
+        this.networkDebugger.addPacket( new PacketBuffer( buffer.getBuffer(), 0 ), batched );
 
         // Grab the packet ID from the packet's data
         byte packetId = buffer.readByte();
@@ -248,7 +248,7 @@ public class UpstreamConnection extends AbstractConnection implements Player {
 
     @Override
     public InetSocketAddress getAddress() {
-        return ( InetSocketAddress ) this.connection.getAddress();
+        return (InetSocketAddress) this.connection.getAddress();
     }
 
     @Override
@@ -271,7 +271,7 @@ public class UpstreamConnection extends AbstractConnection implements Player {
      *
      * @param downstreamConnection The downstream which connected
      */
-    void onDownSteamConnected( DownstreamConnection downstreamConnection ) {
+    void onDownStreamConnected( DownstreamConnection downstreamConnection ) {
         // Close old connection and store new one
         if ( this.currentDownStream != null ) {
             this.lastKnownServer = new ServerDataHolder( this.currentDownStream.getIP(), this.currentDownStream.getPort() );


### PR DESCRIPTION
I've changed "downsteam" to "downstream" where the second option is the correct one, I guess.