### PR TITLE
Move library management out of main class

### DIFF
--- a/guidelines.md
+++ b/guidelines.md
@@ -44,7 +44,7 @@ to follow the above class layout. All blank lines are intentional.
 
 1. Before you begin to declare your class you will need to insert a JavaDoc comment which includes at least
    an author tag that contains your username as well as a version tag which will always contain 1.0 unless
-   you are specifcally advised to change this number. Whenever you make major changes to a class that was not
+   you are specifically advised to change this number. Whenever you make major changes to a class that was not
    created by you make sure to add your name to the authors list.
 2. Notice the blank line right after the opening brace of the class and just before its closing brace.
 3. If your class has got nested enumerations or similar you should put them at the top of the file

--- a/src/main/java/io/gomint/proxprox/Bootstrap.java
+++ b/src/main/java/io/gomint/proxprox/Bootstrap.java
@@ -7,24 +7,14 @@
 
 package io.gomint.proxprox;
 
+import io.gomint.proxprox.util.lib.LibraryHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.net.HttpURLConnection;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
 import java.net.URLClassLoader;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * This Bootstrap downloads all Libraries given inside of the "libs.dep" File in the Root
@@ -34,9 +24,14 @@ import java.util.Map;
  * @author geNAZt
  * @version 1.0
  */
-public class Bootstrap {
+public final class Bootstrap {
 
     private static final Logger LOGGER = LoggerFactory.getLogger( Bootstrap.class );
+    private static LibraryHelper libraryHelper;
+
+    private Bootstrap() {
+        Bootstrap.libraryHelper = new LibraryHelper(this);
+    }
 
     /**
      * Main entry point. May be used for custom dependency injection, dynamic
@@ -46,6 +41,8 @@ public class Bootstrap {
      * @param args The command-line arguments to be passed to the entryClass
      */
     public static void main( String[] args ) {
+        new Bootstrap();
+
         // Check if classloader has been changed (it should be a URLClassLoader)
         if ( !( ClassLoader.getSystemClassLoader() instanceof URLClassLoader ) ) {
             System.out.println( "System Classloader is no URLClassloader" );
@@ -53,181 +50,41 @@ public class Bootstrap {
         }
 
         // Check if we need to create the libs Folder
-        File libsFolder = new File( "libs/" );
-        if ( !libsFolder.exists() && !libsFolder.mkdirs() ) {
-            System.out.println( "Could not create library Directory" );
+        File libraryDirectory = LibraryHelper.LIBRARY_DIRECTORY;
+        if ( !libraryDirectory.exists() && !libraryDirectory.mkdirs() ) {
+            System.out.println( "Failed creating library directory" );
             System.exit( -1 );
         }
 
         // Check the libs (versions and artifacts)
-        checkLibs( libsFolder );
+        libraryHelper.checkDepFile();
 
-        File[] files = libsFolder.listFiles();
+        File[] files = libraryDirectory.listFiles();
         if ( files == null ) {
-            System.out.println( "Library Directory is corrupted" );
+            System.out.println( "Library directory is corrupted" );
             System.exit( -1 );
         }
 
-        // Scan the libs/ Directory for .jar Files
+        // Scan the library directory for .jar Files
         for ( File file : files ) {
             if ( file.getAbsolutePath().endsWith( ".jar" ) ) {
                 try {
-                    LOGGER.info( "Loading lib: " + file.getAbsolutePath() );
-                    addJARToClasspath( file );
+                    LOGGER.info( "Loading library: " + file.getAbsolutePath() );
+                    libraryHelper.addJarToClasspath( file );
                 } catch ( IOException e ) {
                     e.printStackTrace();
                 }
             }
         }
 
-        // Load the Class entrypoint
+        // Load the class entry point
         try {
             Class<?> coreClass = ClassLoader.getSystemClassLoader().loadClass( "io.gomint.proxprox.ProxProx" );
             Constructor constructor = coreClass.getDeclaredConstructor( String[].class );
             constructor.newInstance( new Object[]{args} );
-        } catch ( ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException | InstantiationException e ) {
+        } catch ( Exception e ) {
             e.printStackTrace();
         }
     }
 
-    /**
-     * Download needed Libs from the central Maven repository or any other Repo (can be any url in the libs.dep file)
-     *
-     * @param libsFolder in which the downloads should be stored
-     */
-    private static void checkLibs( File libsFolder ) {
-        // Check if we are able to skip this
-        if ( System.getProperty( "skip.libcheck", "false" ).equals( "true" ) ) {
-            return;
-        }
-
-        // Load the dependency list
-        try ( BufferedReader reader = new BufferedReader( new InputStreamReader( Bootstrap.class.getResourceAsStream( "/libs.dep" ) ) ) ) {
-            // Parse the line
-            String line;
-            while ( ( line = reader.readLine() ) != null ) {
-                // Check for comment
-                if ( line.isEmpty() || line.equals( System.getProperty( "line.separator" ) ) || line.startsWith( "#" ) ) {
-                    continue;
-                }
-
-                // Extract the command mode
-                String[] splitCommand = line.split( "~" );
-                switch ( splitCommand[0] ) {
-                    case "delete":
-                        File toDelete = new File( libsFolder, splitCommand[1] );
-                        if ( toDelete.exists() ) {
-                            if ( !toDelete.delete() ) {
-                                LOGGER.error( "Could not delete old version of required lib. Please delete {}", splitCommand[1] );
-                                System.exit( -1 );
-                            } else {
-                                LOGGER.info( "Deleted old version of requried lib {}", splitCommand[1] );
-                            }
-                        }
-
-                        break;
-
-                    case "download":
-                        String libURL = splitCommand[1];
-
-                        // Head first to get informations about the file
-                        URL url = new URL( libURL );
-                        HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
-                        urlConnection.setConnectTimeout( 1000 );
-                        urlConnection.setReadTimeout( 1000 );
-                        urlConnection.setRequestMethod( "HEAD" );
-
-                        // Filter out non java archive content types
-                        if ( !"application/java-archive".equals( urlConnection.getHeaderField( "Content-Type" ) ) ) {
-                            LOGGER.debug( "Skipping the download of {} because its not a Java Archive", libURL );
-                            continue;
-                        }
-
-                        // We need the contentLength to compare
-                        int contentLength = Integer.parseInt( urlConnection.getHeaderField( "Content-Length" ) );
-
-                        String[] tempSplit = url.getPath().split( "/" );
-                        String fileName = tempSplit[tempSplit.length - 1];
-
-                        // Check if we have a file with the same length
-                        File libFile = new File( libsFolder, fileName );
-                        if ( libFile.exists() && libFile.length() == contentLength ) {
-                            LOGGER.debug( "Skipping the download of {} because there already is a correct sized copy", libURL );
-                            continue;
-                        }
-
-                        // Download the file from the Server
-                        Files.copy( url.openStream(), libFile.toPath(), StandardCopyOption.REPLACE_EXISTING );
-                        LOGGER.info( "Downloading library: {}", fileName );
-                        break;
-                }
-            }
-        } catch ( IOException e ) {
-            LOGGER.error( "Could not download needed library: ", e );
-        }
-    }
-
-    /**
-     * Appends a JAR into the System Classloader
-     *
-     * @param moduleFile which should be added to the classpath
-     * @throws IOException
-     */
-    private static void addJARToClasspath( File moduleFile ) throws IOException {
-        URL moduleURL = moduleFile.toURI().toURL();
-        Class[] parameters = new Class[]{URL.class};
-
-        ClassLoader sysloader = ClassLoader.getSystemClassLoader();
-        Class sysclass = URLClassLoader.class;
-
-        try {
-            Method method = sysclass.getDeclaredMethod( "addURL", parameters );
-            method.setAccessible( true );
-            method.invoke( sysloader, new Object[]{moduleURL} );
-        } catch ( NoSuchMethodException | InvocationTargetException | IllegalAccessException e ) {
-            e.printStackTrace();
-            throw new IOException( "Error, could not add URL to system classloader" );
-        }
-    }
-
-    /**
-     * Downloads a library file from the given url
-     *
-     * @param libsFolder The folder where the libraries will be copied into
-     * @param dependency The dependency url to download from
-     */
-    private static void downloadLibraryFile( File libsFolder, String dependency ) {
-        HttpURLConnection urlConnection = null;
-        try {
-            // Head first to get information about the file
-            URL url = new URL( dependency );
-            urlConnection = (HttpURLConnection) url.openConnection();
-            urlConnection.setRequestMethod( "HEAD" );
-
-            // Filter out non java archive content types
-            if ( !"application/java-archive".equals( urlConnection.getHeaderField( "Content-Type" ) ) ) {
-                System.out.println( "Skipping the download of " + dependency + " because its not a Java Archive" );
-                return;
-            }
-
-            // We need the contentLength to compare
-            int contentLength = Integer.parseInt( urlConnection.getHeaderField( "Content-Length" ) );
-
-            String[] tempSplit = url.getPath().split( "/" );
-            String fileName = tempSplit[tempSplit.length - 1];
-
-            // Check if we have a file with the same length
-            File libFile = new File( libsFolder, fileName );
-            if ( libFile.exists() && libFile.length() == contentLength ) {
-                System.out.println( "Skipping the download of " + dependency + " because there already is a correct sized copy" );
-                return;
-            }
-
-            // Download the file from the Server
-            Files.copy( url.openStream(), libFile.toPath(), StandardCopyOption.REPLACE_EXISTING );
-            System.out.println( "Downloading library: " + fileName );
-        } catch ( IOException e ) {
-            e.printStackTrace();
-        }
-    }
 }

--- a/src/main/java/io/gomint/proxprox/Bootstrap.java
+++ b/src/main/java/io/gomint/proxprox/Bootstrap.java
@@ -28,11 +28,7 @@ import java.net.URLClassLoader;
 public final class Bootstrap {
 
     private static final Logger LOGGER = LoggerFactory.getLogger( Bootstrap.class );
-    private static LibraryHelper libraryHelper;
-
-    private Bootstrap() {
-        Bootstrap.libraryHelper = new LibraryHelper(this);
-    }
+    private static final LibraryHelper LIBRARY_HELPER = new LibraryHelper();;
 
     /**
      * Main entry point. May be used for custom dependency injection, dynamic
@@ -58,7 +54,7 @@ public final class Bootstrap {
         }
 
         // Check the libs (versions and artifacts)
-        libraryHelper.checkDepFile();
+        LIBRARY_HELPER.checkDepFile();
 
         File[] files = libraryDirectory.listFiles();
         if ( files == null ) {
@@ -71,7 +67,7 @@ public final class Bootstrap {
             if ( file.getAbsolutePath().endsWith( ".jar" ) ) {
                 try {
                     LOGGER.info( "Loading library: " + file.getAbsolutePath() );
-                    libraryHelper.addJarToClasspath( file );
+                    LIBRARY_HELPER.addJarToClasspath( file );
                 } catch ( IOException e ) {
                     e.printStackTrace();
                 }

--- a/src/main/java/io/gomint/proxprox/Bootstrap.java
+++ b/src/main/java/io/gomint/proxprox/Bootstrap.java
@@ -22,6 +22,7 @@ import java.net.URLClassLoader;
  * entry point.
  *
  * @author geNAZt
+ * @author Shad0wCore
  * @version 1.0
  */
 public final class Bootstrap {

--- a/src/main/java/io/gomint/proxprox/util/lib/LibraryHelper.java
+++ b/src/main/java/io/gomint/proxprox/util/lib/LibraryHelper.java
@@ -86,8 +86,6 @@ public final class LibraryHelper {
     public static final File LIBRARY_DIRECTORY = new File("libs/");
     public static final Logger LOGGER = LoggerFactory.getLogger(LibraryHelper.class);
 
-    public LibraryHelper(Bootstrap bootstrap) { }
-
     public void checkDepFile() {
         // Check if we are able to skip this
         if (System.getProperty("skip.libCheck", "false").equals("true")) { return; }

--- a/src/main/java/io/gomint/proxprox/util/lib/LibraryHelper.java
+++ b/src/main/java/io/gomint/proxprox/util/lib/LibraryHelper.java
@@ -1,0 +1,151 @@
+package io.gomint.proxprox.util.lib;
+
+import io.gomint.proxprox.Bootstrap;
+import io.gomint.proxprox.util.lib.handler.DeleteAllLibraryActionHandler;
+import io.gomint.proxprox.util.lib.handler.DeleteLibraryActionHandler;
+import io.gomint.proxprox.util.lib.handler.DownloadLibraryActionHandler;
+import io.gomint.proxprox.util.lib.handler.LibraryActionHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.*;
+
+/**
+ * Providing functionality to fetch libraries and storing them locally.
+ * {@code LibraryHelper} makes use of {@link LibraryActionHandler} to handle different variations
+ * of commands / actions. Currently the {@code LibraryHelper} comes with these action handler
+ * standard implementations:
+ * <ul>
+ * <li>Download: Downloads a library by using the given URL ~ {@link DownloadLibraryActionHandler}</li>
+ * <li>Delete: Deletes a library ~ {@link DeleteLibraryActionHandler}</li>
+ * <li>DeleteAll: Deletes all saved libraries ~ {@link DeleteAllLibraryActionHandler}</li>
+ * </ul>
+ *
+ * @author Shad0wCore
+ * @version 1.0
+ */
+public final class LibraryHelper {
+
+    public static final File LIBRARY_DIRECTORY = new File("libs/");
+    public static final Logger LOGGER = LoggerFactory.getLogger(LibraryHelper.class);
+
+    private static class ActionRegistry {
+        /* Registered handlers */
+        private static final Map<String, Class<? extends LibraryActionHandler>> ACTION_HANDLERS = new HashMap<>();
+        private static final Logger LOGGER = LoggerFactory.getLogger(ActionRegistry.class);
+
+        /* Default handlers*/
+        static {
+            assignHandler("download", DownloadLibraryActionHandler.class);
+            assignHandler("delete", DeleteLibraryActionHandler.class);
+            assignHandler("deleteAll", DeleteAllLibraryActionHandler.class);
+        }
+
+        // TODO Block default handler overwrite
+        /* For now, only protected access granted until a implementation were made not overriding default handlers */
+        static void assignHandler(String action, Class<? extends LibraryActionHandler> handlerClass) {
+            if (action == null) { LOGGER.warn("Failed assigning handler: 'action' is referring to null"); return;}
+            if (handlerClass == null) { LOGGER.warn("Failed assigning handler: 'handlerClass' is referring to null"); return;}
+
+            /* Avoid having pointless exceptions when instantiating a handler */
+            if (handlerClass.isInterface() || Modifier.isAbstract(handlerClass.getModifiers())) {
+                LOGGER.warn("Failed assigning handler: Class cannot be an interface nor can it be abstract");
+                return;
+            }
+
+            ACTION_HANDLERS.put(action, handlerClass);
+            LOGGER.debug("Assignment was made: '" + action + "' <- " + handlerClass.getName());
+        }
+
+        static LibraryActionHandler getHandler(String action) {
+            if (action == null) { LOGGER.debug("Failed gathering handler: 'action' is referring to null"); return null;}
+            if (ACTION_HANDLERS.isEmpty()) { return null; }
+
+            Class<? extends LibraryActionHandler> handlerClass = ACTION_HANDLERS.get(action);
+            LibraryActionHandler libraryActionHandler = null;
+
+            // TODO Store single instance of action handler, stop instantiating every time a new action handler
+            try {
+                Constructor constructor = handlerClass.getDeclaredConstructor();
+                constructor.setAccessible(true);
+
+                libraryActionHandler = (LibraryActionHandler) constructor.newInstance();
+            } catch (Exception e) {
+                LOGGER.error("Encountered errors while instantiating action handler:", e);
+            }
+
+            return libraryActionHandler;
+        }
+
+    }
+
+    public LibraryHelper(Bootstrap bootstrap) { }
+
+    public void checkDepFile() {
+        // Check if we are able to skip this
+        if (System.getProperty("skip.libCheck", "false").equals("true")) { return; }
+
+        try(BufferedReader reader = getBufferedReaderOfDepFile()) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                // Check for comment, if commented skip action
+                if (line.isEmpty() || line.equals(System.getProperty("line.separator")) || line.startsWith("#")) { continue; }
+
+                String[] actionCompounds = line.split("~");
+                String[] handlerArgs = Arrays.copyOfRange(actionCompounds, 1, actionCompounds.length);
+
+                dispatchAction(actionCompounds[0], handlerArgs);
+            }
+        } catch (IOException e) {
+            LOGGER.error("Failed checking dependency file: ", e);
+        }
+    }
+
+    public void download(URL libraryUrl) {
+        dispatchAction("download", libraryUrl.toString(), LIBRARY_DIRECTORY.toString());
+    }
+
+    public void download(String libraryUrl) {
+        dispatchAction("download", libraryUrl, LIBRARY_DIRECTORY.toString());
+    }
+
+    public void delete(String libraryName) {
+        dispatchAction("delete", libraryName, LIBRARY_DIRECTORY.toString());
+    }
+
+    public void deleteAll() {
+        dispatchAction("deleteAll", LIBRARY_DIRECTORY.toString());
+    }
+
+    public void dispatchAction(String action, String... args) {
+        LibraryActionHandler handler = ActionRegistry.getHandler(action);
+        if (handler == null) { LOGGER.warn("Could not dispatch action: No handler available for '" + action + "'"); return; }
+
+        handler.handleAction(action, LIBRARY_DIRECTORY, args);
+    }
+
+    /* Appends a Jar file to the classpath from ClassLoader#getSystemClassLoader() */
+    public void addJarToClasspath(File jarFile) throws IOException {
+        if (jarFile == null) { LOGGER.debug("Failed appending jar to classpath: 'jarFile' is referring to null"); return;}
+
+        try {
+            Method addUrlMethod = URLClassLoader.class.getDeclaredMethod("addURL", URL.class);
+            addUrlMethod.setAccessible(true);
+            addUrlMethod.invoke(ClassLoader.getSystemClassLoader(), jarFile.toURI().toURL());
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            LOGGER.error("Failed appending jar to classpath: ", e);
+        }
+    }
+
+    private BufferedReader getBufferedReaderOfDepFile() {
+        return new BufferedReader(new InputStreamReader(Bootstrap.class.getResourceAsStream("/libs.dep")));
+    }
+
+}

--- a/src/main/java/io/gomint/proxprox/util/lib/LibraryHelper.java
+++ b/src/main/java/io/gomint/proxprox/util/lib/LibraryHelper.java
@@ -29,19 +29,16 @@ import java.util.*;
  * </ul>
  *
  * @author Shad0wCore
- * @version 1.0
+ * @version 1.0.1
  */
 public final class LibraryHelper {
-
-    public static final File LIBRARY_DIRECTORY = new File("libs/");
-    public static final Logger LOGGER = LoggerFactory.getLogger(LibraryHelper.class);
 
     private static class ActionRegistry {
         /* Registered handlers */
         private static final Map<String, Class<? extends LibraryActionHandler>> ACTION_HANDLERS = new HashMap<>();
         private static final Logger LOGGER = LoggerFactory.getLogger(ActionRegistry.class);
 
-        /* Default handlers*/
+        // ====================================== DEFAULT HANDLERS ====================================== //
         static {
             assignHandler("download", DownloadLibraryActionHandler.class);
             assignHandler("delete", DeleteLibraryActionHandler.class);
@@ -86,6 +83,9 @@ public final class LibraryHelper {
 
     }
 
+    public static final File LIBRARY_DIRECTORY = new File("libs/");
+    public static final Logger LOGGER = LoggerFactory.getLogger(LibraryHelper.class);
+
     public LibraryHelper(Bootstrap bootstrap) { }
 
     public void checkDepFile() {
@@ -108,18 +108,30 @@ public final class LibraryHelper {
         }
     }
 
+    // ====================================== DOWNLOAD ====================================== //
+
+    /** @deprecated Planed for removal. Not being used as {@link Bootstrap} is using the {@link #checkDepFile()} method */
+    @Deprecated
     public void download(URL libraryUrl) {
         dispatchAction("download", libraryUrl.toString(), LIBRARY_DIRECTORY.toString());
     }
 
+    /** @deprecated Planed for removal. Not being used as {@link Bootstrap} is using the {@link #checkDepFile()} method */
+    @Deprecated
     public void download(String libraryUrl) {
         dispatchAction("download", libraryUrl, LIBRARY_DIRECTORY.toString());
     }
 
+    // ====================================== DELETE ====================================== //
+
+    /** @deprecated Planed for removal. Not being used as {@link Bootstrap} is using the {@link #checkDepFile()} method */
+    @Deprecated
     public void delete(String libraryName) {
         dispatchAction("delete", libraryName, LIBRARY_DIRECTORY.toString());
     }
 
+    /** @deprecated Planed for removal. Not being used as {@link Bootstrap} is using the {@link #checkDepFile()} method */
+    @Deprecated
     public void deleteAll() {
         dispatchAction("deleteAll", LIBRARY_DIRECTORY.toString());
     }

--- a/src/main/java/io/gomint/proxprox/util/lib/handler/DeleteAllLibraryActionHandler.java
+++ b/src/main/java/io/gomint/proxprox/util/lib/handler/DeleteAllLibraryActionHandler.java
@@ -1,0 +1,42 @@
+package io.gomint.proxprox.util.lib.handler;
+
+import org.apache.logging.log4j.core.util.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static io.gomint.proxprox.util.lib.LibraryHelper.LOGGER;
+
+public class DeleteAllLibraryActionHandler implements LibraryActionHandler {
+
+    @Override
+    public void handleAction(String action, File workingDirectory, String... args) {
+        if (!"deleteAll".equalsIgnoreCase(action)) {
+            LOGGER.warn("Triggered " + getClass().getName() + ": Action[" + action + "] does not equal 'deleteAll'");
+            LOGGER.warn("Unexpected behaviour may occur. Continuing.");
+        }
+
+        if (args == null) { LOGGER.error("Failed handling action: 'args' is referring to null"); return; }
+
+        if (workingDirectory.exists()) {
+            try {
+                Files.walk(workingDirectory.toPath()).filter(path -> {
+                    String fileExtension = FileUtils.getFileExtension(path.toFile());
+                    return "jar".equalsIgnoreCase(fileExtension);
+                }).forEach(path -> {
+                    try {
+                        Files.delete(path);
+                    } catch (IOException e) {
+                        LOGGER.warn("Failed deleting library: ", e);
+                    }
+                });
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        } else {
+            LOGGER.warn("Given library directory does not exist: " + workingDirectory.getAbsolutePath());
+        }
+    }
+
+}

--- a/src/main/java/io/gomint/proxprox/util/lib/handler/DeleteLibraryActionHandler.java
+++ b/src/main/java/io/gomint/proxprox/util/lib/handler/DeleteLibraryActionHandler.java
@@ -1,0 +1,32 @@
+package io.gomint.proxprox.util.lib.handler;
+
+import java.io.File;
+
+import static io.gomint.proxprox.util.lib.LibraryHelper.LOGGER;
+
+public class DeleteLibraryActionHandler implements LibraryActionHandler {
+
+
+    @Override
+    public void handleAction(String action, File workingDirectory, String... args) {
+        if (!"delete".equalsIgnoreCase(action)) {
+            LOGGER.warn("Triggered " + getClass().getName() + ": Action[" + action + "] does not equal 'delete'");
+            LOGGER.warn("Unexpected behaviour may occur. Continuing.");
+        }
+
+        if (args == null) { LOGGER.error("Failed handling action: 'args' is referring to null"); return; }
+
+        String libraryName = args[0];
+        File toDelete = new File(workingDirectory, libraryName);
+
+        if (toDelete.exists()) {
+            if (!toDelete.delete()) {
+                LOGGER.error("Failed deleting old version of library. Please delete {} manually", libraryName);
+                System.exit(-1);
+            } else {
+                LOGGER.info("Deleting old version of library {}", libraryName);
+            }
+        }
+    }
+
+}

--- a/src/main/java/io/gomint/proxprox/util/lib/handler/DownloadLibraryActionHandler.java
+++ b/src/main/java/io/gomint/proxprox/util/lib/handler/DownloadLibraryActionHandler.java
@@ -1,0 +1,60 @@
+package io.gomint.proxprox.util.lib.handler;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+
+import static io.gomint.proxprox.util.lib.LibraryHelper.LOGGER;
+
+public class DownloadLibraryActionHandler implements LibraryActionHandler {
+
+    @Override
+    public void handleAction(String action, File workingDirectory, String... args) {
+        if (!"download".equalsIgnoreCase(action)) {
+            LOGGER.warn("Triggered " + getClass().getName() + ": Action[" + action + "] does not equal 'download'");
+            LOGGER.warn("Unexpected behaviour may occur. Continuing.");
+        }
+
+        if (args == null) { LOGGER.error("Failed handling action: 'args' is referring to null"); return; }
+
+        String libUrlRaw = args[0];
+
+        try {
+            URL libUrl = new URL(libUrlRaw);
+            HttpURLConnection urlConnection = (HttpURLConnection) libUrl.openConnection();
+            urlConnection.setConnectTimeout(1000);
+            urlConnection.setReadTimeout(1000);
+
+            // Head first to receive information of what type the file is
+            urlConnection.setRequestMethod("HEAD");
+
+            // Filter out non java archive content types
+            if (!"application/java-archive".equals(urlConnection.getHeaderField("Content-Type"))) {
+                LOGGER.debug("Skipping {}: Not a Java archive", libUrlRaw);
+                return;
+            }
+
+            // We need the contentLength to compare
+            int contentLength = Integer.parseInt(urlConnection.getHeaderField("Content-Length"));
+            String[] tempSplit = libUrl.getPath().split("/");
+            String fileName = tempSplit[tempSplit.length - 1];
+
+            // Check if we have a file with the same length
+            File libFile = new File(workingDirectory, fileName);
+            if (libFile.exists() && libFile.length() == contentLength) {
+                LOGGER.debug("Skipping {}: Correct sized copy already present [@" + libFile.getAbsolutePath() + "]", libUrlRaw);
+                return;
+            }
+
+            // Download the file from url source
+            Files.copy(libUrl.openStream(), libFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            LOGGER.info("Downloading library: {}", fileName);
+        } catch (IOException e) {
+            LOGGER.error("Could not download library: ", e);
+        }
+    }
+
+}

--- a/src/main/java/io/gomint/proxprox/util/lib/handler/LibraryActionHandler.java
+++ b/src/main/java/io/gomint/proxprox/util/lib/handler/LibraryActionHandler.java
@@ -1,0 +1,9 @@
+package io.gomint.proxprox.util.lib.handler;
+
+import java.io.File;
+
+public interface LibraryActionHandler {
+
+    void handleAction(String action, File workingDirectory, String... args);
+
+}


### PR DESCRIPTION
I thought it would be better to move library management completely out of the Bootstrap class. 
You can use the `LibraryActionHandler` interface to implement a new action quickly. 

For instance, you want a new action called `nyancat`... (Didn't have any other idea) - Grab the interface, implement the logic and assign the handler (interface) to `nyancat` by calling `LibraryHelper.ActionRegistry#assignHandler(String, Class)`. Works flawlessly.

Actual goal is to shrink down the main class, making it look less huge.
Uh, also, I fixed some typos. 

The new implementation has been tested several times. Bugs have been fixed.

(I have no way to format my code like it is being stated in the guidelines. I have tried my best by rearranging some bits of code here and there. I would appreciate it if you could reformat the code how you would like him to be formatted)