### PR TITLE
Update to 1.8.0

### DIFF
--- a/proxprox-server/src/main/java/io/gomint/proxprox/network/Protocol.java
+++ b/proxprox-server/src/main/java/io/gomint/proxprox/network/Protocol.java
@@ -14,8 +14,8 @@ package io.gomint.proxprox.network;
 public class Protocol {
 
     public static final int MINECRAFT_PE_BETA_PROTOCOL_VERSION = -1;
-    public static final int MINECRAFT_PE_PROTOCOL_VERSION = 291;
-    public static final String MINECRAFT_PE_NETWORK_VERSION = "1.7.0";
+    public static final int MINECRAFT_PE_PROTOCOL_VERSION = 313;
+    public static final String MINECRAFT_PE_NETWORK_VERSION = "1.8.0";
 
     /**
      * Packet ID of the login packet


### PR DESCRIPTION
Tested: True
-----
Server OS: Windows Server 2016
Client OS: Windows 10
Client: Minecraft Windows 10 Edition
-----
Maven Version: Latest
JDK Version: 1.8
-----

![image](https://user-images.githubusercontent.com/34005016/50431875-a5ee0400-0900-11e9-9774-ea8ee447eee4.png)
